### PR TITLE
Fix MSR Bitmap Bug

### DIFF
--- a/hv/vmx.inl
+++ b/hv/vmx.inl
@@ -302,27 +302,45 @@ inline void inject_hw_exception(uint32_t const vector, uint32_t const error) {
 // enable/disable vm-exits when the guest tries to read the specified MSR
 inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
     uint32_t const msr, bool const enable_exiting) {
-  auto const bit = static_cast<uint8_t>(enable_exiting ? 1 : 0);
+  auto const bit = 1 << (msr & 0b0111);
 
-  if (msr <= MSR_ID_LOW_MAX)
-    // set the bit in the low bitmap
-    bitmap.rdmsr_low[msr / 8] = (bit << (msr & 0b0111));
-  else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX)
-    // set the bit in the high bitmap
-    bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] = (bit << (msr & 0b0111));
+  if (msr <= MSR_ID_LOW_MAX) {
+	// update the bit in the low bitmap
+	if(enable_exiting)
+	  bitmap.rdmsr_low[msr / 8] |= bit;
+    else
+	  bitmap.rdmsr_low[msr / 8] &= ~bit;
+  }
+
+  else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
+	// update the bit in the high bitmap
+	if(enable_exiting)
+	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
+	else
+	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
+  }
 }
 
 // enable/disable vm-exits when the guest tries to write to the specified MSR
 inline void enable_exit_for_msr_write(vmx_msr_bitmap& bitmap,
     uint32_t const msr, bool const enable_exiting) {
-  auto const bit = static_cast<uint8_t>(enable_exiting ? 1 : 0);
+  auto const bit = 1 << (msr & 0b0111);
 
-  if (msr <= MSR_ID_LOW_MAX)
-    // set the bit in the low bitmap
-    bitmap.wrmsr_low[msr / 8] = (bit << (msr & 0b0111));
-  else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX)
-    // set the bit in the high bitmap
-    bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] = (bit << (msr & 0b0111));
+  if (msr <= MSR_ID_LOW_MAX) {
+	// update the bit in the low bitmap
+	if(enable_exiting)
+	  bitmap.wrmsr_low[msr / 8] |= bit;
+    else
+	  bitmap.wrmsr_low[msr / 8] &= ~bit;
+  }
+
+  else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
+    // update the bit in the high bitmap
+	if(enable_exiting)
+	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
+    else
+	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
+  }
 }
 
 // enable MTF exiting

--- a/hv/vmx.inl
+++ b/hv/vmx.inl
@@ -306,18 +306,18 @@ inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
 
   if (msr <= MSR_ID_LOW_MAX) {
 	// update the bit in the low bitmap
-    if(enable_exiting)
-	  bitmap.rdmsr_low[msr / 8] |= bit;
+    if (enable_exiting)
+      bitmap.rdmsr_low[msr / 8] |= bit;
     else
-	  bitmap.rdmsr_low[msr / 8] &= ~bit;
+      bitmap.rdmsr_low[msr / 8] &= ~bit;
   }
 
   else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
 	// update the bit in the high bitmap
-    if(enable_exiting)
-	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
+    if (enable_exiting)
+      bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
     else
-	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
+      bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
   }
 }
 
@@ -328,18 +328,18 @@ inline void enable_exit_for_msr_write(vmx_msr_bitmap& bitmap,
 
   if (msr <= MSR_ID_LOW_MAX) {
 	// update the bit in the low bitmap
-    if(enable_exiting)
-	  bitmap.wrmsr_low[msr / 8] |= bit;
+    if (enable_exiting)
+      bitmap.wrmsr_low[msr / 8] |= bit;
     else
-	  bitmap.wrmsr_low[msr / 8] &= ~bit;
+      bitmap.wrmsr_low[msr / 8] &= ~bit;
   }
 
   else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
     // update the bit in the high bitmap
-    if(enable_exiting)
-	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
+    if (enable_exiting)
+      bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
     else
-	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
+      bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
   }
 }
 

--- a/hv/vmx.inl
+++ b/hv/vmx.inl
@@ -305,7 +305,7 @@ inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
   auto const bit = 1 << (msr & 0b0111);
 
   if (msr <= MSR_ID_LOW_MAX) {
-	// update the bit in the low bitmap
+    // update the bit in the low bitmap
     if (enable_exiting)
       bitmap.rdmsr_low[msr / 8] |= bit;
     else
@@ -313,7 +313,7 @@ inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
   }
 
   else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
-	// update the bit in the high bitmap
+    // update the bit in the high bitmap
     if (enable_exiting)
       bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
     else
@@ -327,7 +327,7 @@ inline void enable_exit_for_msr_write(vmx_msr_bitmap& bitmap,
   auto const bit = 1 << (msr & 0b0111);
 
   if (msr <= MSR_ID_LOW_MAX) {
-	// update the bit in the low bitmap
+    // update the bit in the low bitmap
     if (enable_exiting)
       bitmap.wrmsr_low[msr / 8] |= bit;
     else

--- a/hv/vmx.inl
+++ b/hv/vmx.inl
@@ -306,7 +306,7 @@ inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
 
   if (msr <= MSR_ID_LOW_MAX) {
 	// update the bit in the low bitmap
-	if(enable_exiting)
+    if(enable_exiting)
 	  bitmap.rdmsr_low[msr / 8] |= bit;
     else
 	  bitmap.rdmsr_low[msr / 8] &= ~bit;
@@ -314,9 +314,9 @@ inline void enable_exit_for_msr_read(vmx_msr_bitmap& bitmap,
 
   else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
 	// update the bit in the high bitmap
-	if(enable_exiting)
+    if(enable_exiting)
 	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
-	else
+    else
 	  bitmap.rdmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;
   }
 }
@@ -328,7 +328,7 @@ inline void enable_exit_for_msr_write(vmx_msr_bitmap& bitmap,
 
   if (msr <= MSR_ID_LOW_MAX) {
 	// update the bit in the low bitmap
-	if(enable_exiting)
+    if(enable_exiting)
 	  bitmap.wrmsr_low[msr / 8] |= bit;
     else
 	  bitmap.wrmsr_low[msr / 8] &= ~bit;
@@ -336,7 +336,7 @@ inline void enable_exit_for_msr_write(vmx_msr_bitmap& bitmap,
 
   else if (msr >= MSR_ID_HIGH_MIN && msr <= MSR_ID_HIGH_MAX) {
     // update the bit in the high bitmap
-	if(enable_exiting)
+    if(enable_exiting)
 	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] |= bit;
     else
 	  bitmap.wrmsr_high[(msr - MSR_ID_HIGH_MIN) / 8] &= ~bit;


### PR DESCRIPTION
A direct assignment is used to update the bits in the MSR bitmap. Doing so will overwrite the seven other bits to zero, possibly leading to undesirable behavior. Fix this by using compound bitwise assignments.